### PR TITLE
exclude xrefmap from build scope

### DIFF
--- a/Docs/docfx.json
+++ b/Docs/docfx.json
@@ -8,6 +8,7 @@
         ],
         "exclude": [
           "**/obj/**",
+          "**/xrefmap.yml",
           "**/includes/**",
           "README.md",
           "LICENSE",


### PR DESCRIPTION
Xrefmap.yml is just used for resolving xref, it should not be added to build scope, or it will be built as a content file.
This Fix won't bring any impact to your current published content page.