### PR TITLE
Revert http schemas

### DIFF
--- a/Docs/Overview/key-and-key-ids-kids.md
+++ b/Docs/Overview/key-and-key-ids-kids.md
@@ -18,7 +18,7 @@ Within each PRO is a *PlayReady Header*, which gives a client the information ne
 
 ```xml
 
-<WRMHEADER xmlns="https://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader" version="4.2.0.0">
+<WRMHEADER xmlns="http://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader" version="4.2.0.0">
   <DATA>
     <PROTECTINFO>
       <KIDS>

--- a/Docs/Overview/license-server.md
+++ b/Docs/Overview/license-server.md
@@ -48,13 +48,13 @@ The following is a license request sample:
 <?xml version="1.0" encoding="utf-8"?>
 <soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
 	<soap:Body>
-		<AcquireLicense xmlns="https://schemas.microsoft.com/DRM/2007/03/protocols">
+		<AcquireLicense xmlns="http://schemas.microsoft.com/DRM/2007/03/protocols">
 			<challenge>
-				<Challenge xmlns="https://schemas.microsoft.com/DRM/2007/03/protocols/messages">
-					<LA xmlns="https://schemas.microsoft.com/DRM/2007/03/protocols" Id="SignedData" xml:space="preserve">
+				<Challenge xmlns="http://schemas.microsoft.com/DRM/2007/03/protocols/messages">
+					<LA xmlns="http://schemas.microsoft.com/DRM/2007/03/protocols" Id="SignedData" xml:space="preserve">
 						<Version>1</Version>
 						<ContentHeader>
-							<WRMHEADER xmlns="https://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader" version="4.0.0.0">
+							<WRMHEADER xmlns="http://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader" version="4.0.0.0">
 								<DATA>
 									<PROTECTINFO>
 										<KEYLEN>16</KEYLEN>
@@ -80,7 +80,7 @@ The following is a license request sample:
 							<EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc"></EncryptionMethod>
 							<KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
 								<EncryptedKey xmlns="http://www.w3.org/2001/04/xmlenc#">
-									<EncryptionMethod Algorithm="https://schemas.microsoft.com/DRM/2007/03/protocols#ecc256"></EncryptionMethod>
+									<EncryptionMethod Algorithm="http://schemas.microsoft.com/DRM/2007/03/protocols#ecc256"></EncryptionMethod>
 									<KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
 										<KeyName>WMRMServer</KeyName>
 									</KeyInfo>
@@ -97,9 +97,9 @@ The following is a license request sample:
 					<Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
 						<SignedInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
 							<CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"></CanonicalizationMethod>
-							<SignatureMethod Algorithm="https://schemas.microsoft.com/DRM/2007/03/protocols#ecdsa-sha256"></SignatureMethod>
+							<SignatureMethod Algorithm="http://schemas.microsoft.com/DRM/2007/03/protocols#ecdsa-sha256"></SignatureMethod>
 							<Reference URI="#SignedData">
-								<DigestMethod Algorithm="https://schemas.microsoft.com/DRM/2007/03/protocols#sha256"></DigestMethod>
+								<DigestMethod Algorithm="http://schemas.microsoft.com/DRM/2007/03/protocols#sha256"></DigestMethod>
 								<DigestValue>NnkxTbC9yLGwYWSRfOz3VqKRYd62AGqTnwpSHsCklhI=</DigestValue>
 							</Reference>
 						</SignedInfo>
@@ -127,10 +127,10 @@ The following is a license response sample:
 <?xml version="1.0" encoding="utf-8"?>
 <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
 	<soap:Body>
-		<AcquireLicenseResponse xmlns="https://schemas.microsoft.com/DRM/2007/03/protocols">
+		<AcquireLicenseResponse xmlns="http://schemas.microsoft.com/DRM/2007/03/protocols">
 			<AcquireLicenseResult>
-				<Response xmlns="https://schemas.microsoft.com/DRM/2007/03/protocols/messages">
-					<LicenseResponse xmlns="https://schemas.microsoft.com/DRM/2007/03/protocols" Id="SignedData">
+				<Response xmlns="http://schemas.microsoft.com/DRM/2007/03/protocols/messages">
+					<LicenseResponse xmlns="http://schemas.microsoft.com/DRM/2007/03/protocols" Id="SignedData">
 						<Version>1</Version>
 						<Licenses>
 							<License>WE1SAAAAAANryW57jI0QQJItXt7rxagIAAMAAQAAAWIAAgAEAAAACAADAAIAAABEAAEAEgAAABAAAAAAVjOhZgAAABMAAAAMVjOhKgABADIAAAAMAAAAHgABADQAAAAKB9AAAAAzAAAACgABAAMACQAAAPIAAQAKAAAAnowA4DNExHBHmJmjIeB53TYAAQADAIAKFe+fsiOCUo/ndSfV1p0YK1qzUAgypRhiMUObPbmJ+P3GMFziaM+O0jHVttk0TAxxGsreh3PumUKJJ1CYMCYGJSgFm7ceuCsOxRBKCJcH+jGVlocmKMw0zrG41DeTrgDLw/rDDEDtmQvIwezIcwUwqWFxq7o5+kYWA4TdwTZNRAAAACoAAABMAAEAQOSjiOqgw3D8yP0vsKUOkh9SDIb3OghTm5812xCi7Y1q+Yr2U6KPQAUDgandzhhSKvebDjmWCIhxcjv+cIE5WIsAAQALAAAAHAABABBDCGMQnJ3JfqzT5K+5nS5k</License>
@@ -163,9 +163,9 @@ The following is a license response sample:
 					<Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
 						<SignedInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
 							<CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"></CanonicalizationMethod>
-							<SignatureMethod Algorithm="https://schemas.microsoft.com/DRM/2007/03/protocols#ecdsa-sha256"></SignatureMethod>
+							<SignatureMethod Algorithm="http://schemas.microsoft.com/DRM/2007/03/protocols#ecdsa-sha256"></SignatureMethod>
 							<Reference URI="#SignedData">
-								<DigestMethod Algorithm="https://schemas.microsoft.com/DRM/2007/03/protocols#sha256"></DigestMethod>
+								<DigestMethod Algorithm="http://schemas.microsoft.com/DRM/2007/03/protocols#sha256"></DigestMethod>
 								<DigestValue>H9QaFwGEr4BnkJX0nRoztartIba7dcvEU5G1vYu9jTs=</DigestValue>
 							</Reference>
 						</SignedInfo>

--- a/Docs/Packaging/content-encryption-modes.md
+++ b/Docs/Packaging/content-encryption-modes.md
@@ -75,7 +75,7 @@ The following is an example of a PlayReady Header v4.2.
 ```xml
 <WRMHEADER
           version="4.2.0.0"
-          xmlns="https://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader">
+          xmlns="http://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader">
   <DATA>
     <PROTECTINFO>
       <KIDS>
@@ -95,7 +95,7 @@ The ALGID (algorithm identifier) is a property of the KID element, and specifies
 ```xml
 <WRMHEADER
           version="4.3.0.0"
-          xmlns="https://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader">
+          xmlns="http://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader">
   <DATA>
     <PROTECTINFO>
       <KIDS>
@@ -121,7 +121,7 @@ Starting with the PlayReady Header version 4.3, the ALGID may be missing. The fo
 ```xml
 <WRMHEADER
           version="4.3.0.0"
-          xmlns="https://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader">
+          xmlns="http://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader">
   <DATA>
     <PROTECTINFO>
       <KIDS>

--- a/Docs/Packaging/how-to-generate-playready-header.md
+++ b/Docs/Packaging/how-to-generate-playready-header.md
@@ -21,7 +21,7 @@ The PlayReady Header contains information about the content being played back, i
 The following XML code provides an example of a PlayReady Header, which may be inserted in the header of a segmented MP4 file, typically for On-Demand content. It includes the list of KIDs (the IDs of the content encryption keys) that are needed for a client to decrypt the content. It is the most common way to signal these KIDs for an On-Demand file or stream. 
 
 ```xml
-<WRMHEADER xmlns="https://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader" version="4.3.0.0">
+<WRMHEADER xmlns="http://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader" version="4.3.0.0">
   <DATA>
     <PROTECTINFO>
       <KIDS>
@@ -41,7 +41,7 @@ The following XML code provides an example of a PlayReady Header for Live Linear
 >DECRYPTORSETUP = ONDEMAND does not mean the content is served On-Demand, it is actually the opposite.
 
 ```xml
-<WRMHEADER version="4.2.0.0" xmlns="https://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader">
+<WRMHEADER version="4.2.0.0" xmlns="http://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader">
   <DATA>
     <DECRYPTORSETUP>ONDEMAND</DECRYPTORSETUP>
   </DATA>
@@ -78,7 +78,7 @@ void buildRMObject(string KeyID1, string KeyID2, string encryptMode, string doma
 	// encryptMode - the encryption mode used to encrypt content, can be AESCTR or AESCBC
 	// domainID - the optional domain service identifier (only used for domains)
 
-	string xmlString = "<WRMHEADER xmlns=\"https://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader\" version=\"4.3.0.0\"><DATA><PROTECTINFO><KIDS><KID ALGID=\"";
+	string xmlString = "<WRMHEADER xmlns=\"http://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader\" version=\"4.3.0.0\"><DATA><PROTECTINFO><KIDS><KID ALGID=\"";
 	xmlString.append(encryptMode);
 	xmlString.append("\" VALUE=\"");
 	xmlString.append(KeyID1);
@@ -132,7 +132,7 @@ public void buildRMHeader(string KeyID1, string KeyID2, string encryptMode, stri
     string prHeader;
 
     // Create the PlayReady Header
-    prHeader = "<WRMHEADER xmlns=\"https://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader\" version=\"4.3.0.0\"><DATA><PROTECTINFO><KIDS><KID ALGID=\"";
+    prHeader = "<WRMHEADER xmlns=\"http://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader\" version=\"4.3.0.0\"><DATA><PROTECTINFO><KIDS><KID ALGID=\"";
     prHeader += encryptMode;
     prHeader += "\" VALUE=\"";
     prHeader += KeyID1;

--- a/Docs/Packaging/how-to-package-mp4-based.md
+++ b/Docs/Packaging/how-to-package-mp4-based.md
@@ -28,7 +28,7 @@ For example, a PlayReady client needs to know what Key IDs (KIDs) are used in th
 
 Here is an example of a PlayReady Header
 ```xml
-<WRMHEADER xmlns="https://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader" version="4.3.0.0">
+<WRMHEADER xmlns="http://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader" version="4.3.0.0">
   <DATA>
     <PROTECTINFO>
       <KIDS>

--- a/Docs/Packaging/mp4-based-formats-supported-by-playready-clients.md
+++ b/Docs/Packaging/mp4-based-formats-supported-by-playready-clients.md
@@ -391,7 +391,7 @@ QualityLevels(128003)/Manifest(aac_UND_2_128,format=m3u8-aapl)
 PlayReady Header in the master playlist and the individual playlists:
 
 ```xml
-<WRMHEADER version="4.2.0.0" xmlns="https://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader">
+<WRMHEADER version="4.2.0.0" xmlns="http://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader">
   <DATA>
     <DECRYPTORSETUP>ONDEMAND</DECRYPTORSETUP>
   </DATA>
@@ -487,7 +487,7 @@ Here is the Smooth Streaming Manifest extracted from the test stream `http://pla
 
 The manifest includes the PlayReady Header:
 ```xml
-<WRMHEADER xmlns="https://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader" version="4.1.0.0">
+<WRMHEADER xmlns="http://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader" version="4.1.0.0">
 <DATA>
   <DECRYPTORSETUP>ONDEMAND</DECRYPTORSETUP>
 </DATA>

--- a/Docs/Specifications/playready-header-specification.md
+++ b/Docs/Specifications/playready-header-specification.md
@@ -157,12 +157,12 @@ All namespace attributes must be before non-namespaces attributes.
 <table>
     <tr>
         <td>• Supported</td>
-        <td>&lt;WRMHEADER xmlns=&quot;<a href="https://schemas.microsoft.com/DRM/2007/03/PlayReady" data-raw-source="https://schemas.microsoft.com/DRM/2007/03/PlayReady">https://schemas.microsoft.com/DRM/2007/03/PlayReady</a>
+        <td>&lt;WRMHEADER xmlns=&quot;<a href="http://schemas.microsoft.com/DRM/2007/03/PlayReady" data-raw-source="http://schemas.microsoft.com/DRM/2007/03/PlayReady">http://schemas.microsoft.com/DRM/2007/03/PlayReady</a>
 Header&quot; version=&quot;4.3.0.0&quot;&gt;</td>
     </tr>
     <tr>
         <td style="border: none">• Not supported</td>
-        <td style="border: none">&lt;WRMHEADER version=&quot;4.3.0.0&quot; xmlns=&quot;<a href="https://schemas.microsoft.com/DRM/" data-raw-source="https://schemas.microsoft.com/DRM/">https://schemas.microsoft.com/DRM/</a>
+        <td style="border: none">&lt;WRMHEADER version=&quot;4.3.0.0&quot; xmlns=&quot;<a href="http://schemas.microsoft.com/DRM/" data-raw-source="http://schemas.microsoft.com/DRM/">http://schemas.microsoft.com/DRM/</a>
 2007/03/PlayReadyHeader&quot;&gt;</td>
     </tr>
 </table>
@@ -203,7 +203,7 @@ The PlayReady Header format v.4.3.0.0 has the following changes compared to v4.2
 The following is an example of a PlayReady Header 4.3.0.0 with AESCBC keys:
 
 ```xml
-<WRMHEADER xmlns="https://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader" version="4.3.0.0">
+<WRMHEADER xmlns="http://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader" version="4.3.0.0">
   <DATA>
     <PROTECTINFO>
       <KIDS>
@@ -220,7 +220,7 @@ The following is an example of a PlayReady Header 4.3.0.0 with AESCBC keys:
 The following is an example of a PlayReady Header 4.3.0.0 with a missing ALGID:
 
 ```xml
-<WRMHEADER xmlns="https://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader" version="4.3.0.0">
+<WRMHEADER xmlns="http://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader" version="4.3.0.0">
   <DATA>
     <PROTECTINFO>
       <KIDS>
@@ -239,7 +239,7 @@ The following is an example of a PlayReady Header 4.3.0.0 with a missing ALGID:
 The PlayReady Header v4.3.0.0 has the following syntax.
 
 ```xml
-<WRMHEADER xmlns="https://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader" version="4.3.0.0">
+<WRMHEADER xmlns="http://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader" version="4.3.0.0">
   <DATA>
       <PROTECTINFO>
         <KIDS>
@@ -302,7 +302,7 @@ The PlayReady Header format v.4.2.0.0 has the following changes compared to v4.1
 PlayReady Header 4.2.0.0 with two AESCTR keys:
 
 ```xml
-<WRMHEADER xmlns="https://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader" version="4.2.0.0">
+<WRMHEADER xmlns="http://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader" version="4.2.0.0">
   <DATA>
     <PROTECTINFO>
       <KIDS>
@@ -321,7 +321,7 @@ PlayReady Header 4.2.0.0 with two AESCTR keys:
 The PlayReady Header v4.2.0.0 has the following syntax.
 
 ```xml
-<WRMHEADER xmlns="https://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader" version="4.2.0.0">
+<WRMHEADER xmlns="http://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader" version="4.2.0.0">
   <DATA>
       <PROTECTINFO>
         <KIDS>
@@ -388,7 +388,7 @@ The PlayReady Header format v.4.1.0.0 has the following changes compared to v4.0
 The PlayReady Header v4.1.0.0 has the following syntax.
 
 ```xml
-<WRMHEADER xmlns="https://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader" version="4.1.0.0">
+<WRMHEADER xmlns="http://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader" version="4.1.0.0">
   <DATA>
       <PROTECTINFO>
         <KID ALGID="AESCTR" CHECKSUM=“base64-encoded value” VALUE="base64-encoded guid"></KID>
@@ -443,7 +443,7 @@ PlayReady Header v4.0.0.0 was introduced with PlayReady version 1.0 in 2008 and 
 PlayReady Header 4.0.0.0:
 
 ```xml
-<WRMHEADER xmlns="https://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader" version="4.0.0.0">
+<WRMHEADER xmlns="http://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader" version="4.0.0.0">
   <DATA>
     <PROTECTINFO>
       <ALGID>AESCTR</ALGID>
@@ -469,7 +469,7 @@ XAMAAAEAAQBSAzwAVwBSAE0ASABFAEEARABFAFIAIAB4AG0AbABuAHMAPQAiAGgAdAB0AHAAOgAvAC8A
 The PlayReady Header v4.0.0.0 has the following syntax.
 
 ```xml
-<WRMHEADER xmlns="https://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader" version="4.0.0.0">
+<WRMHEADER xmlns="http://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader" version="4.0.0.0">
 <DATA>
       <PROTECTINFO>
         <ALGID>AESCTR</ALGID>


### PR DESCRIPTION
Revert https://schemas back to http://schemas, since it is a plain text, but not clickable link.
Refer to previous PR - https://github.com/MicrosoftDocs/PlayReady/pull/61/files.