### PR TITLE
Fix a couple minor documentation issues in the 4.4's what's new new page and the server overview page

### DIFF
--- a/Docs/Overview/servers.md
+++ b/Docs/Overview/servers.md
@@ -8,7 +8,7 @@ ms.topic: conceptual
 ---
 
 # PlayReady Servers
-PlayReady Servers can take different forms depending on whether they are programmed to deliver licenses, or manage PlayReady domains of clients, or receive and aggregate metering data from clients, and so on. These logical Servers are all developed in C# based on the same PlayReady Server SDK, and a single Server application can implement one or several of the PlayReady Server functionalities.
+PlayReady Servers can take different forms depending on whether they are programmed to deliver licenses, or manage PlayReady domains of clients, or receive and aggregate metering data from clients, and so on. These logical Servers are all developed in C# based on the same [PlayReady Server SDK](https://docs.microsoft.com/dotnet/api/microsoft.media.drm), and a single Server application can implement one or several of the PlayReady Server functionalities.
 
 
 ## PlayReady License Server
@@ -107,3 +107,5 @@ The following operations are supported. For a formal definition, please review t
 [PlayReady Test Server](https://test.playready.microsoft.com/)
 
 [PlayReady Test License Server](https://test.playready.microsoft.com/service/rightsmanager.asmx)
+
+[PlayReady Server SDK](https://docs.microsoft.com/dotnet/api/microsoft.media.drm)

--- a/Docs/Overview/servers.md
+++ b/Docs/Overview/servers.md
@@ -8,7 +8,7 @@ ms.topic: conceptual
 ---
 
 # PlayReady Servers
-PlayReady Servers can take different forms depending on whether they are programmed to deliver licenses, or manage PlayReady domains of clients, or receive and aggregate metering data from clients, and so on. These logical Servers are all developed in C# based on the same [PlayReady Server SDK](https://docs.microsoft.com/dotnet/api/microsoft.media.drm), and a single Server application can implement one or several of the PlayReady Server functionalities.
+PlayReady Servers can take different forms depending on whether they are programmed to deliver licenses, or manage PlayReady domains of clients, or receive and aggregate metering data from clients, and so on. These logical Servers are all developed in C# based on the same [PlayReady Server SDK](/dotnet/api/microsoft.media.drm), and a single Server application can implement one or several of the PlayReady Server functionalities.
 
 
 ## PlayReady License Server
@@ -108,4 +108,4 @@ The following operations are supported. For a formal definition, please review t
 
 [PlayReady Test License Server](https://test.playready.microsoft.com/service/rightsmanager.asmx)
 
-[PlayReady Server SDK](https://docs.microsoft.com/dotnet/api/microsoft.media.drm)
+[PlayReady Server SDK](/dotnet/api/microsoft.media.drm)

--- a/Docs/Overview/what-is-new/what-is-new-4-4.md
+++ b/Docs/Overview/what-is-new/what-is-new-4-4.md
@@ -19,10 +19,6 @@ When multiple non-leaf licenses are acquired in a single license acquisition res
 
 ## General changes in PlayReady Server SDK Version 4.4
 
-Windows now supports CBCS for both hardware and software DRM.  Additionally, the PlayReady license server extends CBCS support for SL2000.
-
-The server can now process SecureStop2 messages. For more information, see [PlayReady Secure Stop](../../Features/secure-stop-pk.md).
-
 A server application can now determine what features the client has implemented if the client is also version 4.4 or higher. For more information, see [How to Determine What Features a Client Supports](../../Advanced/how-to-determine-client-features.md).
 
 Property LicenseResponse.IncludeOptimizedContentKey2 has been added (defaulting to false).


### PR DESCRIPTION
The "What's New" page had two incorrect lines listing changes that were added in 4.2 (and already appear on the 4.2 "What's New" page).  Removed them.

Added links to the PlayReady Server SDK documentation on the Servers Overview page.
