### PR TITLE
Update glossary-and-abbreviations.md

### DIFF
--- a/Docs/Overview/glossary-and-abbreviations.md
+++ b/Docs/Overview/glossary-and-abbreviations.md
@@ -19,7 +19,7 @@ The following high-level terms are used throughout this documentation.
 | AES 128 CBC Content Key | Symmetric Key used to encrypt and decrypt content using the AES algorithm with a key length of 128 bits (or 16 bytes), in CBC mode. Consider the content key as the compound object { Key Value, ALGID }. |
 | AES 128 CTR Content Key | Symmetric key used to encrypt and decrypt content using the AES algorithm with a key length of 128 bits (or 16 bytes), in CTR mode. Consider the content key as the compound object { Key Value, ALGID }. |
 | AMS | Microsoft Azure Media Services. See https://azure.microsoft.com/services/media-services/. |
-| AMS CP | The Content Protection (also known as DRM) functionality available in Microsoft Azure Media Services. For more information, see [Content protection overview](/azure/media-services/). |
+| AMS CP | The Content Protection (also known as DRM) functionality available in Microsoft Azure Media Services. |
 | Anti-rollback clock| A process by which PlayReady detects whether a clock on the client has been reset to an earlier time by the user and triggers a rollback event. |
 | Application Secrets | PlayReady stub library provided to Company and secrets, such as symmetric keys and private keys that reside in the application binary and/or in the process space of the application. |
 | Attacker | Person trying to get unauthorized access to content or client secrets. In digital rights management (DRM), any user may be an attacker. |


### PR DESCRIPTION
Fix broken link per work item https://dev.azure.com/msft-skilling/Content/_workitems/edit/436781.

Remove the link as Azure Media Services is discontinued.